### PR TITLE
Add REPL mode and Dumping to object code

### DIFF
--- a/include/lexer.hpp
+++ b/include/lexer.hpp
@@ -59,23 +59,6 @@ auto OpToStr(OpType) -> std::string;
 
 } // namespace TokenOp
 
-class LexerError : public std::exception {
-public:
-  const int Line;
-  const int Column;
-  const std::string Message;
-  const std::string Filename;
-
-  LexerError(int Line, int Column, std::string Message, std::string Filename);
-  auto message() const -> const std::string;
-  auto what() const noexcept -> const char * override;
-};
-
-class InvalidToken : public LexerError {
-public:
-  InvalidToken(int Line, int Column, std::string Filename);
-};
-
 struct Token {
   const TokenTag Tag;
   const std::string Value;
@@ -84,8 +67,24 @@ struct Token {
   const int Column;
 };
 
+/**
+ * Thrown when the user has made an error (ex: an unknown token)
+ */
+class UserError : public std::runtime_error {
+public:
+  UserError(std::string Filename, int Line, int Column, std::string Message)
+      : std::runtime_error(Filename + ":" + std::to_string(Line) + ":" +
+                           std::to_string(Column) + ": " + Message) {}
+};
+
 class Lexer {
 public:
+  class Error : public UserError {
+  public:
+    Error(int Line, int Column, std::string Message, std::string Filename)
+        : UserError(Filename, Line, Column, "Lexer Error: " + Message){};
+  };
+
   Lexer(std::string_view Source, std::string Filename);
 
   /**

--- a/include/parser.hpp
+++ b/include/parser.hpp
@@ -6,11 +6,11 @@
 #include <optional>
 
 class Parser {
-  class Error : public std::runtime_error {
+  class Error : public UserError {
   public:
-    const Token Found;
-
-    Error(Token Found);
+    Error(Token Found)
+        : UserError(Found.Filename, Found.Line, Found.Column,
+                    "Parser Error: " + Found.Value) {}
   };
 
 public:

--- a/lettucec/CMakeLists.txt
+++ b/lettucec/CMakeLists.txt
@@ -1,4 +1,4 @@
-#set(CMAKE_CXX_CLANG_TIDY clang-tidy)
+set(CMAKE_CXX_CLANG_TIDY clang-tidy)
 
 add_executable(lettucec
         lettucec.cpp # main file for letttucec
@@ -30,7 +30,7 @@ target_compile_options(lettucec PRIVATE
         -Wpedantic
         -Wextra
         -fPIE
-        #        -Werror
+        -Werror
         )
 
 llvm_map_components_to_libnames(llvm_libs support core irreader orcjit nativecodegen)

--- a/lettucec/lexer.cpp
+++ b/lettucec/lexer.cpp
@@ -42,28 +42,6 @@ const std::unordered_map<std::string, TokenTag> KeyWords = {
     {"false", TokenTag::BOOL}, {"and", TokenTag::AND},
     {"or", TokenTag::OR},      {"not", TokenTag::NOT}};
 
-//------------
-// LexerError
-//------------
-
-LexerError::LexerError(int Line, int Column, std::string Message,
-                       std::string Filename)
-    : Line(Line), Column(Column), Message(Message), Filename(Filename) {}
-
-auto LexerError::message() const -> const std::string {
-  std::string S = Filename + ":" + std::to_string(Line) + ":" +
-                  std::to_string(Column) + ": " + Message;
-  return S;
-}
-
-auto LexerError::what() const noexcept -> const char * {
-  const static std::string Msg = message();
-  return const_cast<char *>(Msg.c_str());
-}
-
-InvalidToken::InvalidToken(int Line, int Column, std::string Filename)
-    : LexerError(Line, Column, "Invalid Token", Filename) {}
-
 //--------
 // Lexer
 //--------
@@ -133,7 +111,7 @@ auto Lexer::token() -> Token {
       return Token{TokenTag::BANG_EQUAL, "!=", Filename, StartLine, StartCol};
     }
     // '!' is not a recognized token
-    throw InvalidToken(Line, Column, Filename);
+    throw Error(Line, Column, "Invalid Token", Filename);
   }
   case '(':
     step();
@@ -157,7 +135,7 @@ auto Lexer::token() -> Token {
       return Token{Tag, Value, Filename, StartLine, StartCol};
     }
   }
-  throw InvalidToken(Line, Column, Filename);
+  throw Error(Line, Column, "Invalid Token", Filename);
 }
 
 auto Lexer::peek() -> Token {

--- a/lettucec/parser.cpp
+++ b/lettucec/parser.cpp
@@ -6,12 +6,6 @@
 #include <memory>
 // TODO: EOI?
 
-Parser::Error::Error(Token Found)
-    : std::runtime_error(Found.Filename + ":" + std::to_string(Found.Line) +
-                         ":" + std::to_string(Found.Column) + ": " +
-                         "Parser Error" + ": " + Found.Value),
-      Found(Found) {}
-
 Parser::Parser(Lexer &Lex) : Lex(Lex) {}
 
 auto Parser::parse() -> std::unique_ptr<RootNode> {


### PR DESCRIPTION
- Closes #11 
- Also adds flag "--printDbg" to print AST, MLIR ... in either REPL mode or default
- Removes LLVM IR generation
- Example usage below:
```
~/dev/lettuce/build repl_and_obj *5 !1 ?1
❯ ./lettucec/lettucec 
>>> let i _ 
REPL:1:7: Lexer Error: Invalid Token
>>> let i = =
REPL:1:9: Parser Error: =
>>> let i = 1 in i + 2 
Return value: 3
>>> CTRL-D 
```
```
~/dev/lettuce/build repl_and_obj *5 ?1
❯ cat ../examples/hello.lettuce
let i = (1 + 2) * 3 in i + 4% 
❯ ./lettucec/lettucec ../examples/hello.lettuce
Wrote output.o
❯ clang++ output.o -o output
❯ ./output
❯ echo $?
13
```