### PR TITLE
Reconcile unrealize casts

### DIFF
--- a/examples/if_func_lit.lettuce
+++ b/examples/if_func_lit.lettuce
@@ -1,0 +1,7 @@
+let f =
+    if true then
+        (|x: i32| x + 2)
+    else
+        (|y: i32| y - 2)
+in
+    f(0)

--- a/lettucec/lettucec.cpp
+++ b/lettucec/lettucec.cpp
@@ -12,6 +12,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include <mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
@@ -88,6 +89,10 @@ mlir::OwningOpRef<mlir::ModuleOp> genMLIR(mlir::MLIRContext &Context,
   auto PM = mlir::PassManager(&Context);
   applyPassManagerCLOptions(PM);
   PM.addPass(lettuce::createLowerToLLVMPass());
+
+  // Other passes may independently create unrealized_cast operations.
+  // Reconcile them once at the end
+  PM.addPass(mlir::createReconcileUnrealizedCastsPass());
   if (mlir::failed(PM.run(*Module))) {
     std::cerr << "Failed to lower to LLVM dialect\n";
     std::exit(1);


### PR DESCRIPTION
Fix this bug:

![Screenshot 2023-08-01 at 11 30 22 AM](https://github.com/rkchang/mlidk/assets/12899631/8e13178f-8d2d-467e-855a-c5052b927fcf)

In some cases MLIR would create operations "builtin.unrealized_conversion_cast", which need to be reconciled before outputting LLVM. In our case this seems to be caused when returning a function from any if-expression.